### PR TITLE
Fix "main" definition to point to the rules file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-config-kartotherian",
   "version": "0.0.1",
   "description": "ESLint Kartotherian config",
-  "main": "index.js",
+  "main": ".eslintrc.json",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The module wasn't recognized when running eslint without changing this value.